### PR TITLE
version bumps

### DIFF
--- a/axum-typed-routing-macros/Cargo.toml
+++ b/axum-typed-routing-macros/Cargo.toml
@@ -16,8 +16,8 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-axum = { version = "0.7", features = [] }
-aide = { version = "0.13", features = ["axum"] }
+axum = { version = "0.8", features = [] }
+aide = { version = "0.14", features = ["axum", "axum-json", "axum-query"] }
 serde = { version = "1.0", features = ["derive"] }
 schemars = "0.8"
 

--- a/axum-typed-routing-macros/src/compilation.rs
+++ b/axum-typed-routing-macros/src/compilation.rs
@@ -24,13 +24,16 @@ impl CompiledRoute {
         for (_slash, param) in &self.path_params {
             path.push('/');
             match param {
-                PathParam::Capture(lit, _, _, _) => {
-                    path.push(':');
-                    path.push_str(&lit.value())
+                PathParam::Capture(lit, _brace_1, _, _, _brace_2) => {
+                    path.push('{');
+                    path.push_str(&lit.value());
+                    path.push('}');
                 }
-                PathParam::WildCard(lit, _, _, _) => {
+                PathParam::WildCard(lit, _brace_1, _, _, _, _brace_2) => {
+                    path.push('{');
                     path.push('*');
                     path.push_str(&lit.value());
+                    path.push('}');
                 }
                 PathParam::Static(lit) => path.push_str(&lit.value()),
             }
@@ -79,7 +82,7 @@ impl CompiledRoute {
 
         for (_slash, path_param) in &mut route.path_params {
             match path_param {
-                PathParam::Capture(_lit, _colon, ident, ty) => {
+                PathParam::Capture(_lit, _, ident, ty, _) => {
                     let (new_ident, new_ty) = arg_map.remove_entry(ident).ok_or_else(|| {
                         syn::Error::new(
                             ident.span(),
@@ -89,7 +92,7 @@ impl CompiledRoute {
                     *ident = new_ident;
                     *ty = new_ty;
                 }
-                PathParam::WildCard(_lit, _star, ident, ty) => {
+                PathParam::WildCard(_lit, _, _star, ident, ty, _) => {
                     let (new_ident, new_ty) = arg_map.remove_entry(ident).ok_or_else(|| {
                         syn::Error::new(
                             ident.span(),
@@ -98,7 +101,7 @@ impl CompiledRoute {
                     })?;
                     *ident = new_ident;
                     *ty = new_ty;
-                },
+                }
                 PathParam::Static(_lit) => {}
             }
         }

--- a/axum-typed-routing-macros/src/lib.rs
+++ b/axum-typed-routing-macros/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    token::{Colon, Comma, Slash},
+    token::{Comma, Slash},
     FnArg, GenericArgument, ItemFn, LitStr, Meta, PathArguments, Signature, Type,
 };
 #[macro_use]

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -30,4 +30,3 @@ schemars = "0.8"
 
 [features]
 default = []
-aide = ["dep:aide"]

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -16,14 +16,14 @@ features = ["aide"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
-axum-macros = "0.4"
-aide = { version = "0.13", features = ["axum"], optional = true }
+axum = "0.8"
+axum-macros = "0.5"
+aide = { version = "0.14", features = ["axum"], optional = true }
 axum-typed-routing-macros = { version = "0.2.0", path = "../axum-typed-routing-macros" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-axum-test = { version = "14", features = [] }
+axum-test = { version = "17", features = [] }
 serde = { version = "1", features = ["derive"] }
 json = "0.12"
 schemars = "0.8"

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -30,3 +30,4 @@ schemars = "0.8"
 
 [features]
 default = []
+aide = ["dep:aide"]

--- a/axum-typed-routing/tests/main.rs
+++ b/axum-typed-routing/tests/main.rs
@@ -88,7 +88,7 @@ async fn test_normal() {
     response.assert_text("Hello, 123 - 321 - John!");
 
     let (path, method_router) = generic_handler_with_complex_options::<u32>();
-    assert_eq!(path, "/hello/:id");
+    assert_eq!(path, "/hello/{id}");
 }
 
 #[route(GET "/*")]


### PR DESCRIPTION
bumped versions.
axum 0.8 moved from `:id` to `{id}` and from `*capture` to `{*capture}`.
I changed the macro without breaking. it converts from the old way to the new way. keeping `axum-typed-routing` stable.
maybe it would make sense to release a breaking version of `axum-typed-routing`, I can do that in another PR.
