### PR TITLE
🆙 Update `aide` to `0.15` and `schemars` to `0.9`

### DIFF
--- a/axum-typed-routing-macros/Cargo.toml
+++ b/axum-typed-routing-macros/Cargo.toml
@@ -17,9 +17,9 @@ proc-macro2 = "1"
 
 [dev-dependencies]
 axum = { version = "0.8", features = [] }
-aide = { version = "0.14", features = ["axum", "axum-json", "axum-query"] }
+aide = { version = "0.15", features = ["axum", "axum-json", "axum-query"] }
 serde = { version = "1.0", features = ["derive"] }
-schemars = "0.8"
+schemars = "0.9.0"
 
 [lib]
 proc-macro = true

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -19,7 +19,7 @@ features = ["aide"]
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["query"] }
 axum-macros = "0.5"
-aide = { version = "0.14", features = ["axum", "axum-query"], optional = true }
+aide = { version = "0.15", features = ["axum", "axum-query"], optional = true }
 axum-typed-routing-macros = { version = "0.3.0", path = "../axum-typed-routing-macros" }
 
 [dev-dependencies]
@@ -27,7 +27,7 @@ tokio = { version = "1", features = ["full"] }
 axum-test = { version = "17", features = [] }
 serde = { version = "1.0.209", features = ["derive"] }
 json = "0.12"
-schemars = "0.8"
+schemars = "0.9.0"
 
 [features]
 aide = ["dep:aide"]


### PR DESCRIPTION
`schemars` has a new `0.9` version (there's also `1.0`, but no matching `aide` release has been made yet). Since there are some changes downgrading isn't a easy solution for me. Hence this PR to version bump the dependencies here.