### PR TITLE
Remove unused dependencies and use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["axum-typed-routing-macros", "axum-typed-routing"]
 resolver = "2"
+
+[workspace.dependencies]
+aide = { version = "0.15", features = ["axum", "axum-query"] }
+axum = "0.8"
+serde = { version = "1", features = ["derive"] }
+schemars = "0.9.0"

--- a/axum-typed-routing-macros/Cargo.toml
+++ b/axum-typed-routing-macros/Cargo.toml
@@ -16,10 +16,10 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-axum = { version = "0.8", features = [] }
-aide = { version = "0.15", features = ["axum", "axum-json", "axum-query"] }
-serde = { version = "1.0", features = ["derive"] }
-schemars = "0.9.0"
+axum.workspace = true
+aide.workspace = true
+serde.workspace = true
+schemars.workspace = true
 
 [lib]
 proc-macro = true

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -22,7 +22,7 @@ axum-typed-routing-macros = { version = "0.3.0", path = "../axum-typed-routing-m
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-axum-test = { version = "18", features = [] }
+axum-test = { version = "20", features = [] }
 serde.workspace = true
 schemars.workspace = true
 

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -16,15 +16,15 @@ features = ["aide"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.8"
-aide = { version = "0.15", features = ["axum", "axum-query"], optional = true }
+axum.workspace = true
+aide = { workspace = true, optional = true }
 axum-typed-routing-macros = { version = "0.3.0", path = "../axum-typed-routing-macros" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 axum-test = { version = "18", features = [] }
-serde = { version = "1", features = ["derive"] }
-schemars = "0.9"
+serde.workspace = true
+schemars.workspace = true
 
 [features]
 aide = ["dep:aide"]

--- a/axum-typed-routing/Cargo.toml
+++ b/axum-typed-routing/Cargo.toml
@@ -17,8 +17,6 @@ features = ["aide"]
 
 [dependencies]
 axum = "0.8"
-axum-extra = { version = "0.12", features = ["query"] }
-axum-macros = "0.5"
 aide = { version = "0.15", features = ["axum", "axum-query"], optional = true }
 axum-typed-routing-macros = { version = "0.3.0", path = "../axum-typed-routing-macros" }
 
@@ -26,7 +24,6 @@ axum-typed-routing-macros = { version = "0.3.0", path = "../axum-typed-routing-m
 tokio = { version = "1", features = ["full"] }
 axum-test = { version = "18", features = [] }
 serde = { version = "1", features = ["derive"] }
-json = "0.12"
 schemars = "0.9"
 
 [features]


### PR DESCRIPTION
I noticed that some dependencies don't appear to be used so I removed those.

Then I thought that we might as well make use of workspace dependency versions here. Should make it less likely to have versions become out of sync.